### PR TITLE
Bar padding update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.2.0
-* [BREAKING] Create `CartesianChartStylingData` to replace the earlier style class
-* [BREAKING] Create `CartesianChartStructureData`. Min max values and unit count values need to be moved here.
+* [BREAKING] New class `CartesianChartStylingData` to replace the earlier chart style.
+* [BREAKING] New class `CartesianChartStructureData` created. Min max values and unit count values need to be moved here.
+* [BREAKING] Separate Bar padding into separate value. Each `BarGroup` has a `padding`. `MultiBar` can additionally specify a `spacing` value which is used for adding space between bars of the same group.
 
 ## 0.1.0
 

--- a/example/lib/screens/bar_chart_animation.dart
+++ b/example/lib/screens/bar_chart_animation.dart
@@ -66,7 +66,6 @@ List<BarGroup> makeGroupData(BuildContext context) {
     } else {
       return MultiBar(
         xValue: index + 1,
-        groupSpacing: 10.0,
         yValues: [
           BarData(
             barStyle: const BarDataStyle(

--- a/example/lib/screens/bar_charts_interaction.dart
+++ b/example/lib/screens/bar_charts_interaction.dart
@@ -117,7 +117,6 @@ List<BarGroup> makeGroupData(BuildContext context) {
     } else {
       return MultiBar(
         xValue: index + 1,
-        groupSpacing: 10.0,
         yValues: [
           BarData(
             barStyle: const BarDataStyle(

--- a/lib/src/charts/data/bars/bar_group.dart
+++ b/lib/src/charts/data/bars/bar_group.dart
@@ -25,13 +25,13 @@ abstract class BarGroup with EquatableMixin {
   /// Styling for the Bars in this [BarGroup].
   ///
   /// {@macro bar_styling_order}
-  final BarDataStyle? groupStyle;
+  final BarDataStyle? style;
+
+  /// The amount of padding applied to either side of the bars.
+  final double padding;
 
   /// {@macro bar_group}
-  BarGroup({
-    required this.xValue,
-    this.groupStyle,
-  });
+  BarGroup({required this.xValue, this.style, this.padding = 10});
 
   /// Lerps between two [BarGroup] objects for a factor [t].
   ///

--- a/lib/src/charts/data/bars/multi_bar.dart
+++ b/lib/src/charts/data/bars/multi_bar.dart
@@ -23,10 +23,9 @@ class MultiBar extends BarGroup {
 
   /// The space between consecutive bars in a series arrangement.
   ///
-  /// **Note:** If you've chosen [arrangement] as stack, then do not use
-  /// groupSpacing. Providing a value higher than zero in the case
-  /// will throw an Exception.
-  final double groupSpacing;
+  /// **Note:** If you've chosen [arrangement] as stack, then [spacing] will
+  /// be ignored.
+  final double spacing;
 
   /// Defines a Group of Multiple Bars
   ///
@@ -35,41 +34,35 @@ class MultiBar extends BarGroup {
   ///
   /// See Also: [BarGroup]
   ///
-  MultiBar({
-    required super.xValue,
-    required this.yValues,
-    // defaults to series i.e. side by side
-    this.arrangement = BarGroupArrangement.series,
-    this.groupSpacing = 0.0,
-    super.groupStyle,
-  })  : assert(yValues.isNotEmpty, "At least one yValue is required!"),
-        // Ensure that groupSpacing is not applied when arrangement is stack
-        assert(
-          (arrangement == BarGroupArrangement.stack && groupSpacing > 0.0)
-              ? false
-              : true,
-          "groupSpacing should not be used when Bar Arrangement is Stack!",
-        ),
-        assert(groupSpacing >= 0.0, "groupSpacing cannot be Negative!");
+  MultiBar(
+      {required super.xValue,
+      required this.yValues,
+      // defaults to series i.e. side by side
+      this.arrangement = BarGroupArrangement.series,
+      this.spacing = 10.0,
+      super.style,
+      super.padding})
+      : assert(yValues.isNotEmpty, "At least one yValue is required!"),
+        assert(spacing >= 0.0, "groupSpacing cannot be Negative!");
 
   /// Lerps between two [MultiBar]s for a factor [t]
   static MultiBar lerp(BarGroup? current, BarGroup target, double t) {
     if ((current is MultiBar?) && target is MultiBar) {
       return MultiBar(
-        xValue: lerpDouble(current?.xValue, target.xValue, t) as num,
-        yValues: BarData.lerpBarDataList(current?.yValues, target.yValues, t),
-        arrangement: target.arrangement,
-        groupSpacing: lerpDouble(
-          current?.groupSpacing,
-          target.groupSpacing,
-          t,
-        ).asOrDefault(0.0),
-        groupStyle: BarDataStyle.lerp(
-          current?.groupStyle,
-          target.groupStyle,
-          t,
-        ),
-      );
+          xValue: lerpDouble(current?.xValue, target.xValue, t) as num,
+          yValues: BarData.lerpBarDataList(current?.yValues, target.yValues, t),
+          arrangement: target.arrangement,
+          spacing: lerpDouble(
+            current?.spacing,
+            target.spacing,
+            t,
+          ).asOrDefault(0.0),
+          style: BarDataStyle.lerp(
+            current?.style,
+            target.style,
+            t,
+          ),
+          padding: lerpDouble(current?.padding, target.padding, t) ?? 0.0);
     } else {
       throw Exception('Both current & target data should be of same series!');
     }
@@ -77,5 +70,5 @@ class MultiBar extends BarGroup {
 
   @override
   List<Object?> get props =>
-      [xValue, yValues, groupStyle, groupSpacing, arrangement];
+      [xValue, yValues, style, spacing, arrangement, padding];
 }

--- a/lib/src/charts/data/bars/simple_bar.dart
+++ b/lib/src/charts/data/bars/simple_bar.dart
@@ -3,7 +3,6 @@ import 'dart:ui';
 import 'package:chart_it/src/charts/data/bars/bar_data.dart';
 import 'package:chart_it/src/charts/data/bars/bar_data_style.dart';
 import 'package:chart_it/src/charts/data/bars/bar_group.dart';
-import 'package:chart_it/src/extensions/primitives.dart';
 
 /// Defines a Simple singular Bar with a Single Y-Value
 ///
@@ -12,41 +11,32 @@ class SimpleBar extends BarGroup {
   /// The Y-Value data ([BarData]) for this Bar.
   final BarData yValue;
 
-  /// The space between consecutive bars.
-  final double barSpacing;
-
   /// Defines a Simple singular Bar with a Single Y-Value
   ///
   /// See Also: [BarGroup]
-  SimpleBar({
-    required super.xValue,
-    required this.yValue,
-    this.barSpacing = 5.0,
-    super.groupStyle,
-  });
+  SimpleBar(
+      {required super.xValue,
+      required this.yValue,
+      super.style,
+      super.padding});
 
   /// Lerps between two [SimpleBar]s for a factor [t]
   static SimpleBar lerp(BarGroup? current, BarGroup target, double t) {
     if ((current is SimpleBar?) && target is SimpleBar) {
       return SimpleBar(
-        xValue: lerpDouble(current?.xValue, target.xValue, t) as num,
-        yValue: BarData.lerp(current?.yValue, target.yValue, t),
-        barSpacing: lerpDouble(
-          current?.barSpacing,
-          target.barSpacing,
-          t,
-        ).asOrDefault(0.0),
-        groupStyle: BarDataStyle.lerp(
-          current?.groupStyle,
-          target.groupStyle,
-          t,
-        ),
-      );
+          xValue: lerpDouble(current?.xValue, target.xValue, t) as num,
+          yValue: BarData.lerp(current?.yValue, target.yValue, t),
+          style: BarDataStyle.lerp(
+            current?.style,
+            target.style,
+            t,
+          ),
+          padding: lerpDouble(current?.padding, target.padding, t) ?? 0.0);
     } else {
       throw Exception('Both current & target data should be of same series!');
     }
   }
 
   @override
-  List<Object?> get props => [xValue, yValue, groupStyle];
+  List<Object?> get props => [xValue, yValue, style, padding];
 }

--- a/lib/src/charts/painters/cartesian/bar_painter.dart
+++ b/lib/src/charts/painters/cartesian/bar_painter.dart
@@ -168,7 +168,7 @@ class BarPainter implements CartesianPainter<BarInteractionResult> {
     // Precedence take like this
     // barStyle > groupStyle > seriesStyle > defaultSeriesStyle
     var barStyle = group.yValue.barStyle ??
-        group.groupStyle ??
+        group.style ??
         data.series.seriesStyle ??
         defaultBarSeriesStyle;
 
@@ -186,7 +186,8 @@ class BarPainter implements CartesianPainter<BarInteractionResult> {
       // dx pos to start the bar from
       dxCenter: dxOffset + (data.unitWidth * 0.5) - (data.barWidth * 0.5),
       barWidth: data.barWidth,
-      barSpacing: group.barSpacing,
+      leftPadding: group.padding,
+      rightPadding: group.padding,
       data: data,
     );
     // Finally paint the y-labels for this bar
@@ -213,15 +214,20 @@ class BarPainter implements CartesianPainter<BarInteractionResult> {
     // Start Offset
     var x =
         dxOffset + (data.unitWidth * 0.5) - (data.barWidth * groupCount * 0.5);
+    final padding = group.padding;
+    final spacing = group.spacing;
 
     for (var i = 0; i < groupCount; i++) {
       final barData = group.yValues[i];
       // Precedence take like this
       // barStyle > groupStyle > seriesStyle > defaultSeriesStyle
       var barStyle = barData.barStyle ??
-          group.groupStyle ??
+          group.style ??
           data.series.seriesStyle ??
           defaultBarSeriesStyle;
+
+      final leftPadding = i == 0 ? padding : spacing / 2;
+      final rightPadding = i == groupCount - 1 ? padding : spacing / 2;
 
       _drawBar(
         barGroup: group,
@@ -234,7 +240,8 @@ class BarPainter implements CartesianPainter<BarInteractionResult> {
         // dx pos to start the bar in this group
         dxCenter: x,
         barWidth: data.barWidth,
-        barSpacing: group.groupSpacing,
+        leftPadding: leftPadding,
+        rightPadding: rightPadding,
         data: data,
       );
       // Finally paint the y-labels for this bar
@@ -250,19 +257,20 @@ class BarPainter implements CartesianPainter<BarInteractionResult> {
     }
   }
 
-  _drawBar(
-      {required BarGroup barGroup,
-      required int barGroupIndex,
-      required BarData barData,
-      required int barDataIndex,
-      required Canvas canvas,
-      required CartesianPaintingGeometryData chart,
-      BarDataStyle? style,
-      required double dxCenter,
-      required double barWidth,
-      required double barSpacing,
-      required _BarPainterData data}) {
-    var padding = (barSpacing * 0.5);
+  _drawBar({
+    required BarGroup barGroup,
+    required int barGroupIndex,
+    required BarData barData,
+    required int barDataIndex,
+    required Canvas canvas,
+    required CartesianPaintingGeometryData chart,
+    BarDataStyle? style,
+    required double dxCenter,
+    required double barWidth,
+    required double leftPadding,
+    required double rightPadding,
+    required _BarPainterData data,
+  }) {
     // The first thing to do is to get the data point into the range!
     // This is because we don't want our bar to exceed the min/max values
     // we then multiply it by the vRatio to get the vertical pixel value!
@@ -278,9 +286,9 @@ class BarPainter implements CartesianPainter<BarInteractionResult> {
     var bottomRight = style?.cornerRadius?.bottomRight ?? Radius.zero;
 
     var bar = RRect.fromLTRBAndCorners(
-      dxCenter + padding, // start X + padding
+      dxCenter + leftPadding, // start X + padding
       chart.axisOrigin.dy - y, // axisOrigin's dY - yValue
-      dxCenter + barWidth - padding, // startX + barWidth
+      dxCenter + barWidth - rightPadding, // startX + barWidth
       chart.axisOrigin.dy, // axisOrigin's dY
       // We are swapping top & bottom corners for negative i.e. inverted bar
       topLeft: barData.yValue.isNegative ? bottomLeft : topLeft,


### PR DESCRIPTION
# Description, Motivation and Context:
The current implementation of padding for bars was a little confusing. We had a single value for padding that would apply padding around bars and between bars. It was more confusing because we did not directly apply the padding value. Half of the padding value was added to the left of the bar and half to the right.

This PR makes the following changes in an attempt to make bar padding simpler.
- Seperate values for padding around and between the bar.
- Each `BarGroup` will have a padding value. The provided padding value will be applied to both sides of the bar group. In case of multiple bars, the left side of first bar and the right side of the last bar will get this value.
- Each `MultiBar` has a `spacing` value. This is the amount of spacing between bars of the same group.



